### PR TITLE
Reorder delivery areas to prioritize Climate first

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -311,7 +311,7 @@ function App() {
               bestPractices: 2,
             },
             deliveryAreasLabelKey: 'networks.deliveryAreasLabel',
-            deliveryAreas: ['operational', 'climate'],
+            deliveryAreas: ['climate', 'operational'],
           },
           {
             iconSrc: '/icons/network/soop.svg',
@@ -327,7 +327,7 @@ function App() {
               bestPractices: 3,
             },
             deliveryAreasLabelKey: 'networks.deliveryAreasLabel',
-            deliveryAreas: ['operational', 'climate'],
+            deliveryAreas: ['climate', 'operational'],
           },
           {
             iconSrc: '/icons/network/asap.svg',
@@ -359,7 +359,7 @@ function App() {
               bestPractices: 3,
             },
             deliveryAreasLabelKey: 'networks.deliveryAreasLabel',
-            deliveryAreas: ['operational', 'climate'],
+            deliveryAreas: ['climate', 'operational'],
           },
           {
             iconSrc: '/icons/network/gloss.svg',
@@ -375,7 +375,7 @@ function App() {
               bestPractices: 2,
             },
             deliveryAreasLabelKey: 'networks.deliveryAreasLabel',
-            deliveryAreas: ['operational', 'climate'],
+            deliveryAreas: ['climate', 'operational'],
           },
           {
             iconSrc: '/icons/network/ocean_sites.svg',
@@ -391,7 +391,7 @@ function App() {
               bestPractices: 2,
             },
             deliveryAreasLabelKey: 'networks.deliveryAreasLabel',
-            deliveryAreas: ['climate', 'oceanhealth', 'operational'],
+            deliveryAreas: ['climate', 'operational', 'oceanhealth'],
           },
           {
             iconSrc: '/icons/network/dbcp_moored.svg',
@@ -407,7 +407,7 @@ function App() {
               bestPractices: 2.5,
             },
             deliveryAreasLabelKey: 'networks.deliveryAreasLabel',
-            deliveryAreas: ['operational', 'climate', 'oceanhealth'],
+            deliveryAreas: ['climate', 'operational', 'oceanhealth'],
           },
           {
             iconSrc: '/icons/network/dbcp_moored.svg',
@@ -439,7 +439,7 @@ function App() {
               bestPractices: 3,
             },
             deliveryAreasLabelKey: 'networks.deliveryAreasLabel',
-            deliveryAreas: ['operational', 'climate'],
+            deliveryAreas: ['climate', 'operational'],
           },
           {
             iconSrc: '/icons/network/dbcp_drifters.svg',
@@ -455,7 +455,7 @@ function App() {
               bestPractices: 3,
             },
             deliveryAreasLabelKey: 'networks.deliveryAreasLabel',
-            deliveryAreas: ['operational', 'climate'],
+            deliveryAreas: ['climate', 'operational'],
           },
           {
             iconSrc: '/icons/network/argo.svg',
@@ -471,7 +471,7 @@ function App() {
               bestPractices: 2.5,
             },
             deliveryAreasLabelKey: 'networks.deliveryAreasLabel',
-            deliveryAreas: ['operational', 'climate', 'oceanhealth'],
+            deliveryAreas: ['climate', 'operational', 'oceanhealth'],
           },
           {
             iconSrc: '/icons/network/ocean_gliders.svg',
@@ -487,7 +487,7 @@ function App() {
               bestPractices: 2,
             },
             deliveryAreasLabelKey: 'networks.deliveryAreasLabel',
-            deliveryAreas: ['operational', 'climate', 'oceanhealth'],
+            deliveryAreas: ['climate', 'operational', 'oceanhealth'],
           },
           {
             iconSrc: '/icons/network/ani_bos.svg',
@@ -503,7 +503,7 @@ function App() {
               bestPractices: 2,
             },
             deliveryAreasLabelKey: 'networks.deliveryAreasLabel',
-            deliveryAreas: ['operational', 'climate', 'oceanhealth'],
+            deliveryAreas: ['climate', 'operational', 'oceanhealth'],
           },
         ]}
         backgroundColor="bg-goos-blue-900"


### PR DESCRIPTION
## Summary
Reorder delivery areas in network cards to maintain consistent prioritization with Climate first.

## Changes
- Change delivery area order from operational-first to climate-first
- Consistent ordering across all cards: **Climate**, **Operational**, **Ocean Health**
- Applies to 11 network cards in NetworkCarousel

## Why
Ensures consistent visual hierarchy and aligns with the report's emphasis on climate observations as the primary delivery area.

## Files Changed
- `src/App.tsx`: Updated delivery area ordering for 11 network cards

## Test Plan
- [x] All network cards display delivery areas in correct order
- [x] No functional changes, only reordering
- [x] Visual consistency maintained