### PR TITLE
Fix SOCONET modal text sizing for mobile

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1163,10 +1163,10 @@ function App() {
                 <div className="flex flex-col gap-4 mt-4">
                   <h3 className="text-2xl font-bold text-goos-orange-500">{t('emerging.soconet.title')}</h3>
                   <p
-                    className="text-xl font-normal text-white leading-[1.5]"
+                    className="text-base sm:text-lg md:text-xl font-normal text-white leading-relaxed"
                     dangerouslySetInnerHTML={{ __html: t('emerging.soconet.paragraph1WithLink') }}
                   />
-                  <p className="text-xl font-normal text-white leading-[1.5]">
+                  <p className="text-base sm:text-lg md:text-xl font-normal text-white leading-relaxed">
                     {t('emerging.soconet.paragraph2')}
                   </p>
                   {/* External Link Button */}


### PR DESCRIPTION
## Summary
- Fixed SOCONET modal paragraph text sizing to match other emerging network modals
- Changed from fixed `text-xl` to responsive `text-base sm:text-lg md:text-xl`
- Changed line height from `leading-[1.5]` to `leading-relaxed` for consistency

## Changes
- Modified SOCONET custom modal content in App.tsx
- Text now scales properly on mobile devices (16px → 18px → 20px)
- Matches the responsive sizing pattern used in EmergingNetworkCard component

## Test Plan
- [x] SOCONET modal text displays correctly on mobile
- [x] Text size matches other emerging network modals
- [x] Line height is consistent with other modals
- [x] No visual regressions on tablet/desktop