### PR TITLE
Increase map height on mobile for better visibility

### DIFF
--- a/src/components/MapStatsPanel.tsx
+++ b/src/components/MapStatsPanel.tsx
@@ -175,13 +175,13 @@ export default function MapStatsPanel({
             <img
               src={mapSrc}
               alt={altText}
-              className={`w-full object-cover rounded ${isFullHeight ? 'h-full' : 'h-[400px] sm:h-[500px] md:h-[600px] lg:h-[800px] xl:h-[1000px]'}`}
+              className={`w-full object-cover rounded ${isFullHeight ? 'h-full' : 'h-[600px] sm:h-[500px] md:h-[600px] lg:h-[800px] xl:h-[1000px]'}`}
             />
           ) : (
             <iframe
               src={mapSrc}
               title={altText}
-              className={`w-full border-0 rounded ${isFullHeight ? 'h-full' : 'h-[400px] sm:h-[500px] md:h-[600px] lg:h-[800px] xl:h-[1000px]'}`}
+              className={`w-full border-0 rounded ${isFullHeight ? 'h-full' : 'h-[600px] sm:h-[500px] md:h-[600px] lg:h-[800px] xl:h-[1000px]'}`}
               loading="lazy"
             />
           )}


### PR DESCRIPTION
## Summary
- Increase MapStatsPanel map height on mobile from 400px to 600px
- Improves map content visibility on small screens
- Applies to both image and iframe map types

## Changes
- Updated mobile breakpoint height from h-[400px] to h-[600px]
- Other breakpoints remain unchanged (sm: 500px, md: 600px, lg: 800px, xl: 1000px)

## Files Modified
- src/components/MapStatsPanel.tsx

## Test Plan
- [x] Map displays correctly on mobile viewport
- [x] Height responsive behavior works across all breakpoints
- [x] Both image and iframe maps render properly