### PR TITLE
Remove fixed icon sizing from DataCard

### DIFF
--- a/src/components/DataCard.tsx
+++ b/src/components/DataCard.tsx
@@ -141,7 +141,7 @@ export default function DataCard({
           <img
             src={iconSrc}
             alt={iconAlt}
-            className="object-contain w-6 h-6 sm:w-7 sm:h-7 md:w-8 md:h-8"
+            className="object-contain"
           />
         </div>
 


### PR DESCRIPTION
## Summary
- Remove fixed responsive icon sizing from DataCard component
- Allow parent container to control icon size instead

## Changes

### DataCard.tsx
- Removed: `w-6 h-6 sm:w-7 sm:h-7 md:w-8 md:h-8` classes
- Kept: `object-contain` for proper aspect ratio
- Icon size now controlled by parent container's dimensions

## Technical Details
Previously, the icon had fixed responsive sizes that could conflict with the parent container size. Now the icon will naturally fill its container while maintaining aspect ratio with `object-contain`.

## Test Plan
- [x] Icon renders correctly in DataCard
- [x] Icon maintains aspect ratio
- [x] Icon scales with parent container
- [x] No visual regressions