### PR TITLE
Remove contacts section from satellite platform modal

### DIFF
--- a/src/components/SatelliteTable.tsx
+++ b/src/components/SatelliteTable.tsx
@@ -396,22 +396,6 @@ export default function SatelliteTable() {
                   </p>
                 </div>
 
-                {/* Contacts Section */}
-                <div>
-                  <h3 className="text-base sm:text-lg text-goos-orange-500 mb-2 sm:mb-3">
-                    {t('satelliteObservations.platformModal.contactsTitle')}
-                  </h3>
-                  <div className="space-y-1 text-sm sm:text-base text-white">
-                    <p>{t('satelliteObservations.platformModal.contacts.sst')}</p>
-                    <p>{t('satelliteObservations.platformModal.contacts.sss')}</p>
-                    <p>{t('satelliteObservations.platformModal.contacts.seaLevel')}</p>
-                    <p>{t('satelliteObservations.platformModal.contacts.winds')}</p>
-                    <p>{t('satelliteObservations.platformModal.contacts.seaIce')}</p>
-                    <p>{t('satelliteObservations.platformModal.contacts.seaState')}</p>
-                    <p>{t('satelliteObservations.platformModal.contacts.oceanColor')}</p>
-                  </div>
-                </div>
-
                 {/* SST */}
                 <div>
                   <h3 className="text-base sm:text-lg text-goos-orange-500 mb-2 sm:mb-3">

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -661,16 +661,6 @@
       "title": "Essential Climate and Ocean Variables observed from space",
       "introduction": "This document provides additional information on the adequacy, continuity, and requirements of satellite observations for each Essential Ocean and Climate Variable, as contributed by the satellite ocean observing community. It summarizes the current status and future outlook of satellite measurements for each variable, outlining key achievements, challenges, and planned missions.",
       "moreButton": "More…",
-      "contactsTitle": "Contacts",
-      "contacts": {
-        "sst": "SST: Jorge Vazquez (jorge.vazquez@jpl.nasa.gov), Christina Gonzalez-Haro (cgharo@icm.csic.es)",
-        "sss": "SSS: Severine Fournier (severine.fournier@jpl.nasa.gov)",
-        "seaLevel": "Sea Level: Severine Fournier (severine.fournier@jpl.nasa.gov)",
-        "seaState": "Sea State: Lotfi Aouf (lotfi.aouf@meteo.fr)",
-        "winds": "Winds: Mark Bourassa (bourassa@coaps.fsu.edu); Tong Lee (tlee@jpl.nasa.gov)",
-        "seaIce": "Sea Ice: Ted Maksym (tmaksym@whoi.edu); Stephen Howell (stephen.howell@ec.gc.ca); Walter Meier (walt@colorado.edu)",
-        "oceanColor": "Ocean Color: Christine Lee (christine.lee@jpl.nasa.gov)"
-      },
       "variables": {
         "sst": {
           "title": "SEA SURFACE TEMPERATURE:",


### PR DESCRIPTION
## Summary
- Remove contacts section with email addresses from the Essential Climate and Ocean Variables modal
- Clean up modal content to show only variable information

## Changes

### src/locales/en.json
- Removed `contactsTitle` key
- Removed entire `contacts` object with all email addresses (SST, SSS, Sea Level, Winds, Sea Ice, Sea State, Ocean Color)

### src/components/SatelliteTable.tsx
- Removed Contacts Section rendering block from modal content
- Modal now shows only: Introduction + Variables with expandable details

## Rationale
Simplified modal content by removing email contacts, keeping only technical variable information.

## Test Plan
- [x] Modal opens correctly
- [x] Introduction section displays
- [x] All variables display correctly
- [x] Expandable sections work properly
- [x] No contact information visible