### PR TITLE
Release: 2025 updates, unified asset approach, and content refinements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,75 +1,255 @@
-# React + Vite + TypeScript + Tailwind CSS + i18n
+# OceanOPS Report Card - GOOS Status Report 2024
 
-A minimal React application with Vite, TypeScript, Tailwind CSS, and multilingual support (i18n).
+Interactive web application presenting the Global Ocean Observing System (GOOS) Status Report 2024. Built with React, TypeScript, and modern web technologies to deliver an engaging, multilingual experience showcasing ocean observing networks and their contributions to climate, operational services, and ocean health.
 
 ## Features
 
-- ⚡️ **Vite** - Fast build tool with HMR (Hot Module Replacement)
-- ⚛️ **React 18** - Latest React version
-- 🔷 **TypeScript** - Type safety
-- 🎨 **Tailwind CSS** - Utility-first CSS framework
-- 🌍 **i18next** - Internationalization (English & Spanish)
-- 📏 **ESLint** - Code linting with recommended rules
+- 🌊 **30+ Custom Components** - Modular architecture for data visualization, media galleries, and interactive content
+- 🎨 **GOOS Design System** - Complete color palette with 45 custom Tailwind colors
+- 🌍 **Multilingual Support** - Full internationalization in English, Spanish, and French
+- ⚡️ **Fast Performance** - Vite build tool with Hot Module Replacement (HMR)
+- 🎬 **Smooth Animations** - GSAP-powered entrance effects and scroll triggers
+- 📊 **Data Visualization** - Interactive tables, stats panels, and network cards
+- 🖼️ **Rich Media** - Image galleries, video modals, and carousel components
+- 📱 **Fully Responsive** - Mobile-first design adapting to all screen sizes
+
+## Technologies
+
+- **React 18** - UI library with hooks and functional components
+- **TypeScript 5** - Type safety and enhanced developer experience
+- **Vite 5** - Lightning-fast build tool and dev server
+- **Tailwind CSS 3** - Utility-first styling with custom GOOS theme
+- **react-i18next 14** - Internationalization framework
+- **GSAP** - Professional-grade animation library
+- **Embla Carousel** - Smooth, performant carousels
+- **Roboto Fonts** - Typography via @fontsource
 
 ## Getting Started
 
-### Install Dependencies
+### Prerequisites
+
+- Node.js (v18 or higher recommended)
+- npm or yarn package manager
+
+### Installation
 
 ```bash
+# Clone the repository
+git clone https://github.com/OceanOPS/oceanops-report-card.git
+cd oceanops-report-card
+
+# Install dependencies
 npm install
 ```
 
-### Run Development Server
+### Development
 
 ```bash
+# Start development server
 npm run dev
 ```
 
-The application will start at `http://localhost:5173/` (or another port if 5173 is busy).
+The application will start at different URLs depending on your branch:
+- **staging**: `http://localhost:5173/` (root deployment for Netlify)
+- **main**: `http://localhost:5173/demos/report-card/` (subdirectory deployment for production)
 
-### Verify HMR
+### Build for Production
 
-1. Open the app in your browser
-2. Edit `src/App.tsx` or any component
-3. Save the file
-4. Changes will appear instantly without full page reload
+```bash
+# Type-check and build
+npm run build
+
+# Preview production build
+npm run preview
+```
 
 ## Available Scripts
 
-- `npm run dev` - Start development server
-- `npm run build` - Build for production
-- `npm run lint` - Run ESLint
-- `npm run preview` - Preview production build
+- `npm run dev` - Start development server with HMR
+- `npm run build` - Type-check with TypeScript and build for production
+- `npm run lint` - Run ESLint on all TypeScript files
+- `npm run preview` - Preview production build locally
 
 ## Project Structure
 
 ```
-src/
-├── components/       # React components (currently empty)
-├── locales/         # Translation files
-│   ├── en.json      # English translations
-│   └── es.json      # Spanish translations
-├── App.tsx          # Main application component
-├── main.tsx         # Application entry point
-├── i18n.ts          # i18next configuration
-└── index.css        # Global styles with Tailwind directives
+oceanops-report-card/
+├── public/                    # Static assets
+│   ├── backgrounds/          # Background images
+│   ├── icons/               # Network, physics, and biology icons
+│   ├── images/              # Content images
+│   ├── logos/               # Partner and organization logos
+│   └── videos/              # Video files
+├── src/
+│   ├── components/          # 30+ React components
+│   ├── locales/            # Translation files (en, es, fr)
+│   ├── utils/              # Utility functions (asset path helpers)
+│   ├── App.tsx             # Main application
+│   ├── main.tsx            # Application entry point
+│   ├── i18n.ts             # i18next configuration
+│   └── index.css           # Global styles with Tailwind
+├── tailwind.config.js      # Tailwind + GOOS color configuration
+├── vite.config.ts          # Vite configuration
+└── tsconfig.json           # TypeScript configuration
 ```
 
-## Changing Language
+## Branch Strategy
 
-Click the "English" or "Spanish" buttons in the app to switch between languages.
+The project uses a two-branch workflow:
 
-## Adding New Languages
+```
+feature-branches → staging (testing/preview) → main (production)
+```
 
-1. Create a new JSON file in `src/locales/` (e.g., `fr.json`)
-2. Add translations with the same keys as `en.json`
-3. Import and register it in `src/i18n.ts`
+- **staging** - Default branch for development and testing (deployed to Netlify)
+- **main** - Production branch (deployed to subdirectory)
 
-## Technologies Used
+**Important**: `staging` and `main` have different configurations:
+- `staging`: Deploys to root URL (`/`) for Netlify
+- `main`: Deploys to subdirectory (`/demos/report-card/`) for production
 
-- React 18.2
-- Vite 5
-- TypeScript 5
-- Tailwind CSS 3
-- react-i18next 14
-- ESLint 8
+## Deployment
+
+### Staging (Netlify)
+- **Branch**: `staging`
+- **URL**: Deployed to root path
+- **Purpose**: Testing and preview environment
+
+### Production
+- **Branch**: `main`
+- **URL**: Deployed to `/demos/report-card/` subdirectory
+- **Purpose**: Live production site
+
+## Key Components
+
+### Layout & Structure
+- **Preloader** - Loading screen with progress indicator
+- **CoverModule** - Hero section with background media
+- **ContentModule** - Flexible content sections
+- **Spacer** - Consistent vertical spacing
+
+### Data Display
+- **StatsGrid** - 2×2 statistics grid
+- **DataTable** - Configurable data tables
+- **IconTable** - Tables with icons and legends
+- **DataCard** - Individual data cards
+- **MapStatsPanel** - Map/iframe with optional stats
+
+### Network Components
+- **NetworkCard** - Network information with ratings
+- **NetworkCarousel** - Horizontal scrolling network cards
+- **EmergingNetworkCard** - Media-rich emerging network cards
+- **EmergingNetworkCarousel** - Carousel for emerging networks
+
+### Media Components
+- **ImageGallery** - Carousel with navigation
+- **VideoModal** - YouTube and local video player
+- **ContentModal** - Flexible modal overlay
+- **ImageGrid** - Responsive image grids
+
+### Interactive
+- **Button** - Multi-variant button (link, video, modal)
+- **Tooltip** - Hover tooltips
+- **LanguageSwitcher** - Language toggle
+
+## Internationalization
+
+The application supports three languages:
+- 🇬🇧 **English** (default)
+- 🇪🇸 **Spanish**
+- 🇫🇷 **French**
+
+All user-facing text uses translation keys from `src/locales/` JSON files.
+
+### Adding Translations
+
+1. Update `src/locales/en.json` with new keys
+2. Translate to Spanish in `src/locales/es.json`
+3. Translate to French in `src/locales/fr.json`
+4. Use keys in components via `useTranslation()` hook
+
+## GOOS Color Palette
+
+Custom Tailwind colors with 9 shades each (100-900):
+- **Blue** (`goos-blue`) - Primary brand color
+- **Cyan** (`goos-cyan`) - Light blue accent
+- **Orange** (`goos-orange`) - Attention and highlights
+- **Green** (`goos-green`) - Success and environment
+- **Gray** (`goos-gray`) - Neutral and text
+
+Usage:
+```tsx
+<div className="bg-goos-blue-700 text-white">
+  <h2 className="text-goos-orange-500">Title</h2>
+</div>
+```
+
+## Development Guidelines
+
+### Code Standards
+- Use TypeScript for all components
+- Follow existing component patterns
+- Use translation keys (never hardcode text)
+- Implement responsive design (mobile-first)
+- Add JSDoc comments to all components
+
+### Git Workflow
+1. Create feature branch from `staging`
+2. Develop and test locally
+3. Create PR to `staging` for testing
+4. After approval, merge `staging` to `main` for production
+
+### Commit Messages
+Use clear, descriptive commit messages:
+```bash
+git commit -m "Add NetworkCarousel component with Embla integration"
+git commit -m "Fix TypeScript errors in Button component"
+```
+
+## Troubleshooting
+
+### Port Already in Use
+If port 5173 is busy, Vite will automatically use the next available port.
+
+### Missing Dependencies
+If you encounter import errors, ensure all dependencies are installed:
+```bash
+npm install
+```
+
+### HMR Not Working
+Restart the dev server:
+```bash
+# Press Ctrl+C to stop
+npm run dev
+```
+
+### Build Errors
+Run type-check before building:
+```bash
+npx tsc --noEmit
+npm run build
+```
+
+## Contributing
+
+1. Fork the repository
+2. Create your feature branch (`git checkout -b _featureName`)
+3. Commit your changes
+4. Push to the branch (`git push origin _featureName`)
+5. Open a Pull Request to `staging` branch
+
+## License
+
+[Add license information here]
+
+## Acknowledgments
+
+- **GOOS** - Global Ocean Observing System
+- **OceanOPS** - Ocean Observing System monitoring center
+- **UNESCO IOC** - Intergovernmental Oceanographic Commission
+- **WMO** - World Meteorological Organization
+
+---
+
+**Built with** ⚛️ React • ⚡️ Vite • 🔷 TypeScript • 🎨 Tailwind CSS

--- a/README.md
+++ b/README.md
@@ -239,17 +239,6 @@ npm run build
 4. Push to the branch (`git push origin _featureName`)
 5. Open a Pull Request to `staging` branch
 
-## License
-
-[Add license information here]
-
-## Acknowledgments
-
-- **GOOS** - Global Ocean Observing System
-- **OceanOPS** - Ocean Observing System monitoring center
-- **UNESCO IOC** - Intergovernmental Oceanographic Commission
-- **WMO** - World Meteorological Organization
-
 ---
 
 **Built with** ⚛️ React • ⚡️ Vite • 🔷 TypeScript • 🎨 Tailwind CSS

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# OceanOPS Report Card - GOOS Status Report 2024
+# OceanOPS Report Card - GOOS Status Report 2025
 
-Interactive web application presenting the Global Ocean Observing System (GOOS) Status Report 2024. Built with React, TypeScript, and modern web technologies to deliver an engaging, multilingual experience showcasing ocean observing networks and their contributions to climate, operational services, and ocean health.
+Interactive web application presenting the Global Ocean Observing System (GOOS) Status Report 2025. Built with React, TypeScript, and modern web technologies to deliver an engaging, multilingual experience showcasing ocean observing networks and their contributions to climate, operational services, and ocean health.
 
 ## Features
 
@@ -50,8 +50,10 @@ npm run dev
 ```
 
 The application will start at different URLs depending on your branch:
-- **staging**: `http://localhost:5173/` (root deployment for Netlify)
-- **main**: `http://localhost:5173/demos/report-card/` (subdirectory deployment for production)
+- **staging** or **feature branches**: `http://localhost:5173/` (root deployment)
+- **main**: `http://localhost:5173/demos/report-card/` (subdirectory deployment)
+
+Both use the same code with `asset()` helper - only `vite.config.ts` differs.
 
 ### Build for Production
 
@@ -83,7 +85,8 @@ oceanops-report-card/
 ├── src/
 │   ├── components/          # 30+ React components
 │   ├── locales/            # Translation files (en, es, fr)
-│   ├── utils/              # Utility functions (asset path helpers)
+│   ├── utils/              # Utility functions
+│   │   └── assets.ts       # asset() helper for base URL resolution
 │   ├── App.tsx             # Main application
 │   ├── main.tsx            # Application entry point
 │   ├── i18n.ts             # i18next configuration
@@ -104,9 +107,33 @@ feature-branches → staging (testing/preview) → main (production)
 - **staging** - Default branch for development and testing (deployed to Netlify)
 - **main** - Production branch (deployed to subdirectory)
 
-**Important**: `staging` and `main` have different configurations:
-- `staging`: Deploys to root URL (`/`) for Netlify
-- `main`: Deploys to subdirectory (`/demos/report-card/`) for production
+### Unified Codebase with Divergent Configuration
+
+Both branches use **identical code** with the `asset()` helper function for all asset paths. The only difference is the `vite.config.ts` configuration:
+
+**staging** (`vite.config.ts`):
+```ts
+export default defineConfig({
+  plugins: [react()],
+  // No base path - deploys to root
+})
+```
+- `BASE_URL` = `/`
+- `asset('/images/photo.jpg')` → `/images/photo.jpg`
+- Deployed to: `https://oceanops-report-card.netlify.app/`
+
+**main** (`vite.config.ts`):
+```ts
+export default defineConfig({
+  plugins: [react()],
+  base: '/demos/report-card/',
+})
+```
+- `BASE_URL` = `/demos/report-card/`
+- `asset('/images/photo.jpg')` → `/demos/report-card/images/photo.jpg`
+- Deployed to: `https://oceanops.org/demos/report-card/`
+
+This approach allows seamless cherry-picking of commits between branches without manual path adjustments.
 
 ## Deployment
 
@@ -195,9 +222,11 @@ Usage:
 
 ### Git Workflow
 1. Create feature branch from `staging`
-2. Develop and test locally
+2. Develop and test locally (use `asset()` for all asset paths)
 3. Create PR to `staging` for testing
-4. After approval, merge `staging` to `main` for production
+4. After approval, cherry-pick commits to `main` (no manual edits needed!)
+
+**Note**: Since both branches use `asset()`, cherry-picking commits from `staging` to `main` requires no manual path adjustments. Only `vite.config.ts` differs between branches.
 
 ### Commit Messages
 Use clear, descriptive commit messages:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import ContentBox from './components/ContentBox'
 import MenuSidebar from './components/MenuSidebar'
 import DeliveryAreasNav from './components/DeliveryAreasNav'
 import ColorStripes from './components/ColorStripes'
+import { asset } from './utils/assets'
 
 function App() {
   const { t } = useTranslation()
@@ -235,7 +236,7 @@ function App() {
         backgroundBlendMode="normal"   // Uses luminosity of video with color of background
         // Background Image or Video
         mediaType="video"
-        backgroundMedia="/videos/video.mp4"
+        backgroundMedia={asset("/videos/video.mp4")}
         // Animation control - starts after preloader finishes
         startAnimation={!isLoading}
       />
@@ -299,7 +300,7 @@ function App() {
         </p>
 
         <ImageCaption
-          src="/images/intro1.webp"
+          src={asset("/images/intro1.webp")}
           alt={t('content.section1.intro1ImageAlt')}
           aspectRatio="video"
           objectFit="cover"
@@ -606,7 +607,7 @@ function App() {
           lineColor="bg-goos-orange-500"
         cards={[
           {
-            iconSrc: '/icons/network/vos.svg',
+            iconSrc: asset('/icons/network/vos.svg'),
             iconAlt: 'networks.sotVos.iconAlt',
             titleKey: 'networks.sotVos.title',
             networkUrl: 'https://www.ocean-ops.org/sot/programmes.html#VOS',
@@ -622,7 +623,7 @@ function App() {
             deliveryAreas: ['climate', 'operational'],
           },
           {
-            iconSrc: '/icons/network/xbt-soop.svg',
+            iconSrc: asset('/icons/network/xbt-soop.svg'),
             iconAlt: 'networks.sotXbt.iconAlt',
             titleKey: 'networks.sotXbt.title',
             networkUrl: 'https://www.ocean-ops.org/sot/programmes.html#ASAP',
@@ -638,7 +639,7 @@ function App() {
             deliveryAreas: ['climate', 'operational'],
           },
           {
-            iconSrc: '/icons/network/asap.svg',
+            iconSrc: asset('/icons/network/asap.svg'),
             iconAlt: 'networks.sotAsap.iconAlt',
             titleKey: 'networks.sotAsap.title',
             networkUrl: 'https://www.ocean-ops.org/sot/programmes.html#ASAP',
@@ -654,7 +655,7 @@ function App() {
             deliveryAreas: ['operational'],
           },
           {
-            iconSrc: '/icons/network/go_ship.svg',
+            iconSrc: asset('/icons/network/go_ship.svg'),
             iconAlt: 'networks.goShip.iconAlt',
             titleKey: 'networks.goShip.title',
             networkUrl: 'http://www.go-ship.org/',
@@ -670,7 +671,7 @@ function App() {
             deliveryAreas: ['climate', 'oceanhealth'],
           },
           {
-            iconSrc: '/icons/network/gloss.svg',
+            iconSrc: asset('/icons/network/gloss.svg'),
             iconAlt: 'networks.gloss.iconAlt',
             titleKey: 'networks.gloss.title',
             networkUrl: 'https://gloss-sealevel.org/',
@@ -686,7 +687,7 @@ function App() {
             deliveryAreas: ['climate', 'operational'],
           },
           {
-            iconSrc: '/icons/network/ocean_sites.svg',
+            iconSrc: asset('/icons/network/ocean_sites.svg'),
             iconAlt: 'networks.oceanSites.iconAlt',
             titleKey: 'networks.oceanSites.title',
             networkUrl: 'https://www.ocean-ops.org/oceansites/',
@@ -702,7 +703,7 @@ function App() {
             deliveryAreas: ['climate', 'oceanhealth'],
           },
           {
-            iconSrc: '/icons/network/dbcp_moored.svg',
+            iconSrc: asset('/icons/network/dbcp_moored.svg'),
             iconAlt: 'networks.dbcpMoored.iconAlt',
             titleKey: 'networks.dbcpMoored.title',
             networkUrl: 'https://www.ocean-ops.org/dbcp/',
@@ -718,7 +719,7 @@ function App() {
             deliveryAreas: ['climate', 'operational', 'oceanhealth'],
           },
           {
-            iconSrc: '/icons/network/tsunami_buoys.svg',
+            iconSrc: asset('/icons/network/tsunami_buoys.svg'),
             iconAlt: 'networks.dbcpTsunami.iconAlt',
             titleKey: 'networks.dbcpTsunami.title',
             networkUrl: 'https://www.ocean-ops.org/dbcp/',
@@ -734,7 +735,7 @@ function App() {
             deliveryAreas: ['operational'],
           },
           {
-            iconSrc: '/icons/network/hf_radar.svg',
+            iconSrc: asset('/icons/network/hf_radar.svg'),
             iconAlt: 'networks.hfRadar.iconAlt',
             titleKey: 'networks.hfRadar.title',
             networkUrl: 'http://global-hfradar.org/',
@@ -750,7 +751,7 @@ function App() {
             deliveryAreas: ['climate', 'operational', 'oceanhealth'],
           },
           {
-            iconSrc: '/icons/network/dbcp_drifters.svg',
+            iconSrc: asset('/icons/network/dbcp_drifters.svg'),
             iconAlt: 'networks.dbcpDrifting.iconAlt',
             titleKey: 'networks.dbcpDrifting.title',
             networkUrl: 'https://www.ocean-ops.org/dbcp/platforms/types.html',
@@ -766,7 +767,7 @@ function App() {
             deliveryAreas: ['climate', 'operational'],
           },
           {
-            iconSrc: '/icons/network/argo.svg',
+            iconSrc: asset('/icons/network/argo.svg'),
             iconAlt: 'networks.argo.iconAlt',
             titleKey: 'networks.argo.title',
             networkUrl: 'https://argo.ucsd.edu/',
@@ -782,7 +783,7 @@ function App() {
             deliveryAreas: ['climate', 'operational', 'oceanhealth'],
           },
           {
-            iconSrc: '/icons/network/ocean_gliders.svg',
+            iconSrc: asset('/icons/network/ocean_gliders.svg'),
             iconAlt: 'networks.gliders.iconAlt',
             titleKey: 'networks.gliders.title',
             networkUrl: 'https://www.oceangliders.org/',
@@ -798,7 +799,7 @@ function App() {
             deliveryAreas: ['climate', 'operational', 'oceanhealth'],
           },
           {
-            iconSrc: '/icons/network/ani_bos.svg',
+            iconSrc: asset('/icons/network/ani_bos.svg'),
             iconAlt: 'networks.anibos.iconAlt',
             titleKey: 'networks.anibos.title',
             networkUrl: 'https://anibos.com/',
@@ -1193,84 +1194,84 @@ function App() {
             {
               number: "108",
               tagKey: "dataCards.card1.tag",
-              iconSrc: "/icons/biology_and_ecosystems/Seabirds.png",
+              iconSrc: asset("/icons/biology_and_ecosystems/Seabirds.png"),
               iconAlt: t('dataCards.card1.iconAlt'),
               titleKey: "dataCards.card1.title",
             },
             {
               number: "224",
               tagKey: "dataCards.card2.tag",
-              iconSrc: "/icons/biology_and_ecosystems/Fish.png",
+              iconSrc: asset("/icons/biology_and_ecosystems/Fish.png"),
               iconAlt: t('dataCards.card2.iconAlt'),
               titleKey: "dataCards.card2.title",
             },
             {
               number: "59",
               tagKey: "dataCards.card3.tag",
-              iconSrc: "/icons/biology_and_ecosystems/Hard-coral.png",
+              iconSrc: asset("/icons/biology_and_ecosystems/Hard-coral.png"),
               iconAlt: t('dataCards.card3.iconAlt'),
               titleKey: "dataCards.card3.title",
             },
             {
               number: "192",
               tagKey: "dataCards.card4.tag",
-              iconSrc: "/icons/biology_and_ecosystems/Invertebrates.png",
+              iconSrc: asset("/icons/biology_and_ecosystems/Invertebrates.png"),
               iconAlt: t('dataCards.card4.iconAlt'),
               titleKey: "dataCards.card4.title",
             },
             {
               number: "120",
               tagKey: "dataCards.card5.tag",
-              iconSrc: "/icons/biology_and_ecosystems/Macroalgae.png",
+              iconSrc: asset("/icons/biology_and_ecosystems/Macroalgae.png"),
               iconAlt: t('dataCards.card5.iconAlt'),
               titleKey: "dataCards.card5.title",
             },
             {
               number: "184",
               tagKey: "dataCards.card6.tag",
-              iconSrc: "/icons/biology_and_ecosystems/Marine-mammals.png",
+              iconSrc: asset("/icons/biology_and_ecosystems/Marine-mammals.png"),
               iconAlt: t('dataCards.card6.iconAlt'),
               titleKey: "dataCards.card6.title",
             },
             {
               number: "18",
               tagKey: "dataCards.card7.tag",
-              iconSrc: "/icons/biology_and_ecosystems/Mangroves.png",
+              iconSrc: asset("/icons/biology_and_ecosystems/Mangroves.png"),
               iconAlt: t('dataCards.card7.iconAlt'),
               titleKey: "dataCards.card7.title",
             },
             {
               number: "99",
               tagKey: "dataCards.card8.tag",
-              iconSrc: "/icons/biology_and_ecosystems/Microbes.png",
+              iconSrc: asset("/icons/biology_and_ecosystems/Microbes.png"),
               iconAlt: t('dataCards.card8.iconAlt'),
               titleKey: "dataCards.card8.title",
             },
             {
               number: "230",
               tagKey: "dataCards.card9.tag",
-              iconSrc: "/icons/biology_and_ecosystems/Phytoplankton.png",
+              iconSrc: asset("/icons/biology_and_ecosystems/Phytoplankton.png"),
               iconAlt: t('dataCards.card9.iconAlt'),
               titleKey: "dataCards.card9.title",
             },
             {
               number: "75",
               tagKey: "dataCards.card10.tag",
-              iconSrc: "/icons/biology_and_ecosystems/Seagrass.png",
+              iconSrc: asset("/icons/biology_and_ecosystems/Seagrass.png"),
               iconAlt: t('dataCards.card10.iconAlt'),
               titleKey: "dataCards.card10.title",
             },
             {
               number: "78",
               tagKey: "dataCards.card11.tag",
-              iconSrc: "/icons/biology_and_ecosystems/Sea-turtles.png",
+              iconSrc: asset("/icons/biology_and_ecosystems/Sea-turtles.png"),
               iconAlt: t('dataCards.card11.iconAlt'),
               titleKey: "dataCards.card11.title",
             },
             {
               number: "188",
               tagKey: "dataCards.card12.tag",
-              iconSrc: "/icons/biology_and_ecosystems/Zooplankton.png",
+              iconSrc: asset("/icons/biology_and_ecosystems/Zooplankton.png"),
               iconAlt: t('dataCards.card12.iconAlt'),
               titleKey: "dataCards.card12.title",
             },
@@ -1294,7 +1295,7 @@ function App() {
             videoId: '-MKKMU3_siw',
             previewImage: '/images/fvon.webp',
             imageAlt: 'emerging.fvon.imageAlt',
-            iconSrc: '/icons/network/fishing_vessels.svg',
+            iconSrc: asset('/icons/network/fishing_vessels.svg'),
             iconAlt: 'emerging.fvon.iconAlt',
             titleKey: 'emerging.fvon.title',
             paragraph1Key: 'emerging.fvon.paragraph1',
@@ -1311,7 +1312,7 @@ function App() {
             videoId: 'NoEK7XwOMeU',
             previewImage: '/images/smart_cables.webp',
             imageAlt: 'emerging.smartCables.imageAlt',
-            iconSrc: '/icons/network/smart_cables.svg',
+            iconSrc: asset('/icons/network/smart_cables.svg'),
             iconAlt: 'emerging.smartCables.iconAlt',
             titleKey: 'emerging.smartCables.title',
             paragraph1Key: 'emerging.smartCables.paragraph1',
@@ -1330,7 +1331,7 @@ function App() {
             modalContent: (
               <div className="flex flex-col gap-5">
                 <img
-                  src="/images/soconet.webp"
+                  src={asset("/images/soconet.webp")}
                   alt="SOCONET"
                   className="w-full h-auto object-cover rounded"
                 />
@@ -1358,7 +1359,7 @@ function App() {
                 </div>
               </div>
             ),
-            iconSrc: '/icons/network/surface_ocean_co2.svg',
+            iconSrc: asset('/icons/network/surface_ocean_co2.svg'),
             iconAlt: 'emerging.soconet.iconAlt',
             titleKey: 'emerging.soconet.title',
             paragraph1Key: 'emerging.soconet.paragraph1WithLink',
@@ -1373,7 +1374,7 @@ function App() {
             mediaType: 'image',
             imageSrc: '/images/sunfleet.webp',
             imageAlt: 'emerging.sunFleet.imageAlt',
-            iconSrc: '/icons/network/sun_fleet.svg',
+            iconSrc: asset('/icons/network/sun_fleet.svg'),
             iconAlt: 'emerging.sunFleet.iconAlt',
             titleKey: 'emerging.sunFleet.title',
             paragraph1Key: 'emerging.sunFleet.paragraph1',
@@ -1467,7 +1468,7 @@ function App() {
         {/* Image - Climate 1 */}
         <div className="-mx-4 sm:mx-0">
           <ImageCaption
-            src="/images/climate1.webp"
+            src={asset("/images/climate1.webp")}
             alt="Climate observation"
             caption=""
           />
@@ -1484,7 +1485,7 @@ function App() {
         {/* Image 1 - AMOC time series */}
         <div className="-mx-4 sm:mx-0">
           <ImageCaption
-            src="/images/climate2.webp"
+            src={asset("/images/climate2.webp")}
             alt={t('amoc.imageCaption')}
             caption={t('amoc.imageCaption')}
             aspectRatio="auto"
@@ -1664,7 +1665,7 @@ function App() {
         {/* Image - Operational 1 */}
         <div className="-mx-4 sm:mx-0">
           <ImageCaption
-            src="/images/operational1.webp"
+            src={asset("/images/operational1.webp")}
             alt="Operational observation"
             caption=""
           />
@@ -1762,7 +1763,7 @@ function App() {
         {/* Image - El Niño Forecast */}
         <div className="-mx-4 sm:mx-0">
           <ImageCaption
-            src="/images/operational2.webp"
+            src={asset("/images/operational2.webp")}
             alt={t('elNino.imageCaption')}
           caption={t('elNino.imageCaption')}
           aspectRatio="auto"
@@ -1915,7 +1916,7 @@ function App() {
         {/* Image - Seal foraging trips */}
         <div className="-mx-4 sm:mx-0">
           <ImageCaption
-            src="/images/imos_anim_230624.gif"
+            src={asset("/images/imos_anim_230624.gif")}
             alt={t('oceanHealth.imageCaption')}
           caption={t('oceanHealth.imageCaption')}
           aspectRatio="auto"
@@ -2107,7 +2108,7 @@ function App() {
        <div className="px-0 sm:px-8 md:px-12 lg:px-16 bg-goos-green-100">
        {/* Single Image */}
         <ImageCaption
-          src="/images/sa1.webp"
+          src={asset("/images/sa1.webp")}
           alt="South Africa observation"
           aspectRatio="video"
           objectFit="cover"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -403,6 +403,14 @@ function App() {
             {
               number: t('content.section1.stats.stat1.number'),
               description: t('content.section1.stats.stat1.description'),
+              infoModal: {
+                title: t('content.section1.stats.stat1.infoModalTitle'),
+                content: (
+                  <p className="text-sm sm:text-base text-goos-white leading-relaxed">
+                    {t('content.section1.stats.stat1.infoModalContent')}
+                  </p>
+                ),
+              },
             },
             {
               number: t('content.section1.stats.stat2.number'),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1553,16 +1553,16 @@ function App() {
             headers={[t('amoc.eovTable.physicsTitle')]}
             rows={[
               [
-                { icon: '/icons/physics/Surface-temperature.png', legend: 'Sea surface temperature', iconSize: 'w-16 h-16' },
-                { icon: '/icons/physics/Subsurface-temperature.png', legend: 'Subsurface temperature', iconSize: 'w-16 h-16' },
-                { icon: '/icons/physics/Surface-currents.png', legend: 'Surface currents', iconSize: 'w-16 h-16' },
-                { icon: '/icons/physics/Subsurface-currents.png', legend: 'Subsurface currents', iconSize: 'w-16 h-16' },
+                { icon: asset('/icons/physics/Surface-temperature.png'), legend: 'Sea surface temperature', iconSize: 'w-16 h-16' },
+                { icon: asset('/icons/physics/Subsurface-temperature.png'), legend: 'Subsurface temperature', iconSize: 'w-16 h-16' },
+                { icon: asset('/icons/physics/Surface-currents.png'), legend: 'Surface currents', iconSize: 'w-16 h-16' },
+                { icon: asset('/icons/physics/Subsurface-currents.png'), legend: 'Subsurface currents', iconSize: 'w-16 h-16' },
               ],
               [
-                { icon: '/icons/physics/Surface-salinity.png', legend: 'Sea surface salinity', iconSize: 'w-16 h-16' },
-                { icon: '/icons/physics/Subsurface-salinity.png', legend: 'Subsurface salinity', iconSize: 'w-16 h-16' },
-                { icon: '/icons/physics/Surface-height.png', legend: 'Sea surface height', iconSize: 'w-16 h-16' },
-                { icon: '/icons/physics/Surface-heat-flux.png', legend: 'Surface heat flux', iconSize: 'w-16 h-16' },
+                { icon: asset('/icons/physics/Surface-salinity.png'), legend: 'Sea surface salinity', iconSize: 'w-16 h-16' },
+                { icon: asset('/icons/physics/Subsurface-salinity.png'), legend: 'Subsurface salinity', iconSize: 'w-16 h-16' },
+                { icon: asset('/icons/physics/Surface-height.png'), legend: 'Sea surface height', iconSize: 'w-16 h-16' },
+                { icon: asset('/icons/physics/Surface-heat-flux.png'), legend: 'Surface heat flux', iconSize: 'w-16 h-16' },
               ]
             ]}
             borderColor="border-goos-blue-700"
@@ -1583,10 +1583,10 @@ function App() {
             headers={[t('amoc.eovTable.biogeochemistryTitle')]}
             rows={[
               [
-                { icon: '/icons/biogeochemistry/Oxygen.png', legend: 'Oxygen', iconSize: 'w-16 h-16' },
-                { icon: '/icons/biogeochemistry/Inorganic-carbon.png', legend: 'Inorganic carbon', iconSize: 'w-16 h-16' },
-                { icon: '/icons/biogeochemistry/Dissolved-organic-carbon.png', legend: 'Dissolved organic carbon', iconSize: 'w-16 h-16' },
-                { icon: '/icons/biogeochemistry/Nutrients.png', legend: 'Nutrients', iconSize: 'w-16 h-16' },
+                { icon: asset('/icons/biogeochemistry/Oxygen.png'), legend: 'Oxygen', iconSize: 'w-16 h-16' },
+                { icon: asset('/icons/biogeochemistry/Inorganic-carbon.png'), legend: 'Inorganic carbon', iconSize: 'w-16 h-16' },
+                { icon: asset('/icons/biogeochemistry/Dissolved-organic-carbon.png'), legend: 'Dissolved organic carbon', iconSize: 'w-16 h-16' },
+                { icon: asset('/icons/biogeochemistry/Nutrients.png'), legend: 'Nutrients', iconSize: 'w-16 h-16' },
               ]
             ]}
             borderColor="border-goos-orange-600"
@@ -1782,15 +1782,15 @@ function App() {
             headers={[t('elNino.eovTable.physicsTitle')]}
             rows={[
               [
-                { icon: '/icons/physics/Surface-temperature.png', legend: 'Sea surface temperature', iconSize: 'w-16 h-16' },
-                { icon: '/icons/physics/Subsurface-temperature.png', legend: 'Subsurface temperature', iconSize: 'w-16 h-16' },
-                { icon: '/icons/physics/Surface-currents.png', legend: 'Surface currents', iconSize: 'w-16 h-16' },
-                { icon: '/icons/physics/Subsurface-currents.png', legend: 'Subsurface currents', iconSize: 'w-16 h-16' },
+                { icon: asset('/icons/physics/Surface-temperature.png'), legend: 'Sea surface temperature', iconSize: 'w-16 h-16' },
+                { icon: asset('/icons/physics/Subsurface-temperature.png'), legend: 'Subsurface temperature', iconSize: 'w-16 h-16' },
+                { icon: asset('/icons/physics/Surface-currents.png'), legend: 'Surface currents', iconSize: 'w-16 h-16' },
+                { icon: asset('/icons/physics/Subsurface-currents.png'), legend: 'Subsurface currents', iconSize: 'w-16 h-16' },
               ],
               [
-                { icon: '/icons/physics/Surface-salinity.png', legend: 'Sea surface salinity', iconSize: 'w-16 h-16' },
-                { icon: '/icons/physics/Subsurface-salinity.png', legend: 'Subsurface salinity', iconSize: 'w-16 h-16' },
-                { icon: '/icons/physics/Surface-height.png', legend: 'Sea surface height', iconSize: 'w-16 h-16' },
+                { icon: asset('/icons/physics/Surface-salinity.png'), legend: 'Sea surface salinity', iconSize: 'w-16 h-16' },
+                { icon: asset('/icons/physics/Subsurface-salinity.png'), legend: 'Subsurface salinity', iconSize: 'w-16 h-16' },
+                { icon: asset('/icons/physics/Surface-height.png'), legend: 'Sea surface height', iconSize: 'w-16 h-16' },
                 { icon: '', legend: '' },
               ]
             ]}
@@ -1812,7 +1812,7 @@ function App() {
             headers={[t('elNino.eovTable.biologyTitle')]}
             rows={[
               [
-                { icon: '/icons/biology_and_ecosystems/Fish.png', legend: 'Fish abundance and distribution', iconSize: 'w-16 h-16' },
+                { icon: asset('/icons/biology_and_ecosystems/Fish.png'), legend: 'Fish abundance and distribution', iconSize: 'w-16 h-16' },
               ]
             ]}
             borderColor="border-goos-green-700"
@@ -1951,10 +1951,10 @@ function App() {
             headers={[t('oceanHealth.eovTable.biologyTitle')]}
             rows={[
               [
-                { icon: '/icons/biology_and_ecosystems/Marine-mammals.png', legend: 'Marine mammal abundance and distribution', iconSize: 'w-16 h-16' },
-                { icon: '/icons/biology_and_ecosystems/Sea-turtles.png', legend: 'Sea turtle abundance and distribution', iconSize: 'w-16 h-16' },
-                { icon: '/icons/biology_and_ecosystems/Seabirds.png', legend: 'Seabird abundance and distribution', iconSize: 'w-16 h-16' },
-                { icon: '/icons/biology_and_ecosystems/Fish.png', legend: 'Fish abundance and distribution', iconSize: 'w-16 h-16' },
+                { icon: asset('/icons/biology_and_ecosystems/Marine-mammals.png'), legend: 'Marine mammal abundance and distribution', iconSize: 'w-16 h-16' },
+                { icon: asset('/icons/biology_and_ecosystems/Sea-turtles.png'), legend: 'Sea turtle abundance and distribution', iconSize: 'w-16 h-16' },
+                { icon: asset('/icons/biology_and_ecosystems/Seabirds.png'), legend: 'Seabird abundance and distribution', iconSize: 'w-16 h-16' },
+                { icon: asset('/icons/biology_and_ecosystems/Fish.png'), legend: 'Fish abundance and distribution', iconSize: 'w-16 h-16' },
               ]
             ]}
             borderColor="border-goos-green-700"
@@ -1972,10 +1972,10 @@ function App() {
             headers={[t('oceanHealth.eovTable.physicsTitle')]}
             rows={[
               [
-                { icon: '/icons/physics/Surface-temperature.png', legend: 'Sea surface temperature', iconSize: 'w-16 h-16' },
-                { icon: '/icons/physics/Subsurface-temperature.png', legend: 'Subsurface temperature', iconSize: 'w-16 h-16' },
-                { icon: '/icons/physics/Surface-salinity.png', legend: 'Sea surface salinity', iconSize: 'w-16 h-16' },
-                { icon: '/icons/physics/Subsurface-salinity.png', legend: 'Subsurface salinity', iconSize: 'w-16 h-16' },
+                { icon: asset('/icons/physics/Surface-temperature.png'), legend: 'Sea surface temperature', iconSize: 'w-16 h-16' },
+                { icon: asset('/icons/physics/Subsurface-temperature.png'), legend: 'Subsurface temperature', iconSize: 'w-16 h-16' },
+                { icon: asset('/icons/physics/Surface-salinity.png'), legend: 'Sea surface salinity', iconSize: 'w-16 h-16' },
+                { icon: asset('/icons/physics/Subsurface-salinity.png'), legend: 'Subsurface salinity', iconSize: 'w-16 h-16' },
               ]
             ]}
             borderColor="border-goos-blue-700"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -372,7 +372,7 @@ function App() {
         quote={t('content.section1.quote.text')}
         authorName={t('content.section1.quote.authorName')}
         authorTitle={t('content.section1.quote.authorTitle')}
-        imageSrc="/images/belbeoch.webp"
+        imageSrc={asset("/images/belbeoch.webp")}
         imageAlt="M. Belbéoch"
         height="fullscreen"
         imagePosition="left"
@@ -1293,7 +1293,7 @@ function App() {
             mediaType: 'video',
             videoType: 'youtube',
             videoId: '-MKKMU3_siw',
-            previewImage: '/images/fvon.webp',
+            previewImage: asset('/images/fvon.webp'),
             imageAlt: 'emerging.fvon.imageAlt',
             iconSrc: asset('/icons/network/fishing_vessels.svg'),
             iconAlt: 'emerging.fvon.iconAlt',
@@ -1310,7 +1310,7 @@ function App() {
             mediaType: 'video',
             videoType: 'youtube',
             videoId: 'NoEK7XwOMeU',
-            previewImage: '/images/smart_cables.webp',
+            previewImage: asset('/images/smart_cables.webp'),
             imageAlt: 'emerging.smartCables.imageAlt',
             iconSrc: asset('/icons/network/smart_cables.svg'),
             iconAlt: 'emerging.smartCables.iconAlt',
@@ -1325,7 +1325,7 @@ function App() {
           {
             // SOCONET - Third (Simple image - showing only first photo)
             mediaType: 'image',
-            imageSrc: '/images/soconet.webp',
+            imageSrc: asset('/images/soconet.webp'),
             imageAlt: 'emerging.soconet.imageAlt',
             modalTitle: 'emerging.soconet.title',
             modalContent: (
@@ -1372,7 +1372,7 @@ function App() {
           {
             // SUN Fleet - Fourth (Simple image)
             mediaType: 'image',
-            imageSrc: '/images/sunfleet.webp',
+            imageSrc: asset('/images/sunfleet.webp'),
             imageAlt: 'emerging.sunFleet.imageAlt',
             iconSrc: asset('/icons/network/sun_fleet.svg'),
             iconAlt: 'emerging.sunFleet.iconAlt',
@@ -1608,7 +1608,7 @@ function App() {
         quote={t('amoc.quote2.text')}
         authorName={t('amoc.quote2.author')}
         authorTitle={t('amoc.quote2.position')}
-        imageSrc="/images/yao.webp"
+        imageSrc={asset("/images/yao.webp")}
         imageAlt="Dr. Yao Fu"
         height="fullscreen"
         imagePosition="left"
@@ -1696,7 +1696,7 @@ function App() {
           <ImageGallery
             images={[
               {
-                src: '/images/operational3.webp',
+                src: asset('/images/operational3.webp'),
                 alt: 'Operational observation 3',
                 caption: ''
               }
@@ -1833,7 +1833,7 @@ function App() {
         quote={t('elNino.quote3.text')}
         authorName={t('elNino.quote3.author')}
         authorTitle={t('elNino.quote3.position')}
-        imageSrc="/images/monica.webp"
+        imageSrc={asset("/images/monica.webp")}
         imageAlt="Monica Alvarado Niño"
         height="fullscreen"
         imagePosition="left"
@@ -1892,7 +1892,7 @@ function App() {
           <ImageGallery
             images={[
               {
-                src: '/images/oh1.webp',
+                src: asset('/images/oh1.webp'),
                 alt: 'Ocean health observation 1',
                 caption: ''
               }
@@ -2054,7 +2054,7 @@ function App() {
         quote={t('oceanHealth.quote2.text')}
         authorName={t('oceanHealth.quote2.author')}
         authorTitle={t('oceanHealth.quote2.position')}
-        imageSrc="/images/clive.webp"
+        imageSrc={asset("/images/clive.webp")}
         imageAlt="Dr. Clive McMahon"
         height="fullscreen"
         imagePosition="left"
@@ -2149,7 +2149,7 @@ function App() {
         <VideoModal
           videoType="youtube"
           videoId="ki5EsC2BHO0"
-          previewImage="/images/10k.webp"
+          previewImage={asset("/images/10k.webp")}
           previewAlt="10,000 Ships for the Ocean"
           aspectRatio="video"
         />
@@ -2215,15 +2215,15 @@ function App() {
       <ImageGrid
         images={[
           {
-            src: '/images/content.webp',
+            src: asset('/images/content.webp'),
             alt: t('hero.images.image1'),
           },
           {
-            src: '/images/content2.webp',
+            src: asset('/images/content2.webp'),
             alt: t('hero.images.image2'),
           },
           {
-            src: '/images/content3.webp',
+            src: asset('/images/content3.webp'),
             alt: t('hero.images.image3'),
           },
         ]}

--- a/src/components/ColorStripes.tsx
+++ b/src/components/ColorStripes.tsx
@@ -2,6 +2,7 @@ import { useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { gsap } from 'gsap';
 import { ScrollTrigger } from 'gsap/ScrollTrigger';
+import { asset } from '../utils/assets'
 
 // Registrar el plugin de ScrollTrigger
 gsap.registerPlugin(ScrollTrigger);
@@ -24,9 +25,9 @@ export default function ColorStripes({
   stripeColors,
   className = '',
   deliveryAreas = [
-    { iconSrc: '/icons/climate.png', iconAlt: 'Climate', textKey: 'networks.deliveryAreas.climate', sectionId: 'amoc-section' },
-    { iconSrc: '/icons/operational_services.png', iconAlt: 'Operational Services', textKey: 'networks.deliveryAreas.operational', sectionId: 'elnino-section' },
-    { iconSrc: '/icons/ocean_health.png', iconAlt: 'Ocean Health', textKey: 'networks.deliveryAreas.oceanhealth', sectionId: 'oceanhealth-section' },
+    { iconSrc: asset('/icons/climate.png'), iconAlt: 'Climate', textKey: 'networks.deliveryAreas.climate', sectionId: 'amoc-section' },
+    { iconSrc: asset('/icons/operational_services.png'), iconAlt: 'Operational Services', textKey: 'networks.deliveryAreas.operational', sectionId: 'elnino-section' },
+    { iconSrc: asset('/icons/ocean_health.png'), iconAlt: 'Ocean Health', textKey: 'networks.deliveryAreas.oceanhealth', sectionId: 'oceanhealth-section' },
   ],
   stripeHeight = ''
 }: ColorStripesProps) {

--- a/src/components/CoverModule.tsx
+++ b/src/components/CoverModule.tsx
@@ -23,7 +23,7 @@
  *   year="2025"
  *   yearColor="text-goos-orange"
  *   backgroundColor="bg-goos-blue-900"
- *   backgroundMedia="/backgrounds/ocean.jpg"
+ *   backgroundMedia={asset("/backgrounds/ocean.jpg")}
  *   backgroundOpacity={50}
  *   backgroundPosition="top right"
  *   backgroundSize="cover"

--- a/src/components/DataCard.tsx
+++ b/src/components/DataCard.tsx
@@ -141,7 +141,7 @@ export default function DataCard({
           <img
             src={iconSrc}
             alt={iconAlt}
-            className="object-contain w-6 h-6 sm:w-7 sm:h-7 md:w-8 md:h-8"
+            className="object-contain"
           />
         </div>
 

--- a/src/components/DeliveryAreasNav.tsx
+++ b/src/components/DeliveryAreasNav.tsx
@@ -14,24 +14,25 @@
 
 import { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
+import { asset } from '../utils/assets'
 
 // Delivery area configuration matching NetworkCard component
 const DELIVERY_AREAS = [
   {
     key: 'climate',
-    icon: '/icons/climate.png',
+    icon: asset('/icons/climate.png'),
     labelKey: 'networks.deliveryAreas.climate',
     sectionId: 'amoc-section',
   },
   {
     key: 'operational',
-    icon: '/icons/operational_services.png',
+    icon: asset('/icons/operational_services.png'),
     labelKey: 'networks.deliveryAreas.operational',
     sectionId: 'elnino-section',
   },
   {
     key: 'oceanhealth',
-    icon: '/icons/ocean_health.png',
+    icon: asset('/icons/ocean_health.png'),
     labelKey: 'networks.deliveryAreas.oceanhealth',
     sectionId: 'oceanhealth-section',
   },

--- a/src/components/EmergingNetworkCarousel.tsx
+++ b/src/components/EmergingNetworkCarousel.tsx
@@ -32,7 +32,7 @@
  *     {
  *       imageSrc: '/images/smart-cables.jpg',
  *       imageAlt: 'emerging.smartCables.imageAlt',
- *       iconSrc: '/icons/smart-cables.png',
+ *       iconSrc: asset('/icons/smart-cables.png'),
  *       iconAlt: 'emerging.smartCables.iconAlt',
  *       titleKey: 'emerging.smartCables.title',
  *       descriptionKey: 'emerging.smartCables.description',

--- a/src/components/ImageCaption.tsx
+++ b/src/components/ImageCaption.tsx
@@ -16,14 +16,14 @@
  * @example
  * ```tsx
  * <ImageCaption
- *   src="/images/ocean-research.jpg"
+ *   src={asset("/images/ocean-research.jpg")}
  *   alt="Ocean research vessel"
  *   caption="Photo by John Doe / Ocean Institute"
  * />
  *
  * // Square image with contain fit
  * <ImageCaption
- *   src="/images/logo.png"
+ *   src={asset("/images/logo.png")}
  *   alt="Organization logo"
  *   aspectRatio="square"
  *   objectFit="contain"
@@ -31,7 +31,7 @@
  *
  * // No caption
  * <ImageCaption
- *   src="/images/chart.jpg"
+ *   src={asset("/images/chart.jpg")}
  *   alt="Data chart"
  * />
  * ```

--- a/src/components/InsightPanel.tsx
+++ b/src/components/InsightPanel.tsx
@@ -64,10 +64,11 @@
  * ```
  */
 
-import { ReactNode, useEffect, useRef } from 'react'
+import { ReactNode, useEffect, useRef, useState } from 'react'
 import { gsap } from 'gsap'
 import { ScrollTrigger } from 'gsap/ScrollTrigger'
 import Button from './Button'
+import ContentModal from './ContentModal'
 
 gsap.registerPlugin(ScrollTrigger)
 
@@ -120,6 +121,10 @@ interface StatItem {
   description: string
   linkText?: string
   linkUrl?: string
+  infoModal?: {
+    title: string
+    content: ReactNode
+  }
 }
 
 interface InsightPanelProps {
@@ -160,6 +165,7 @@ export default function InsightPanel({
   const sectionRef = useRef<HTMLElement>(null)
   const largeNumberRef = useRef<HTMLParagraphElement>(null)
   const statNumberRefs = useRef<(HTMLParagraphElement | null)[]>([])
+  const [openModalIndex, setOpenModalIndex] = useState<number | null>(null)
 
   // Helper function to extract numeric value from string (e.g., "129" from "129" or "45" from "$45M")
   const extractNumber = (text: string): number => {
@@ -319,9 +325,33 @@ export default function InsightPanel({
                       <p ref={(el) => (statNumberRefs.current[index] = el)} className={`text-4xl sm:text-5xl md:text-6xl font-light leading-tight ${numberColor}`}>
                         {stat.number}
                       </p>
-                      <p className={`text-sm sm:text-base font-normal ${textColor}`}>
-                        {stat.description}
-                      </p>
+                      <div className="flex items-center gap-2">
+                        <p className={`text-sm sm:text-base font-normal ${textColor}`}>
+                          {stat.description}
+                        </p>
+                        {stat.infoModal && (
+                          <button
+                            onClick={() => setOpenModalIndex(index)}
+                            className={`${textColor} opacity-70 hover:opacity-100 transition-opacity flex-shrink-0`}
+                            aria-label="More information"
+                          >
+                            <svg
+                              width="18"
+                              height="18"
+                              viewBox="0 0 24 24"
+                              fill="none"
+                              stroke="currentColor"
+                              strokeWidth="2"
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                            >
+                              <circle cx="12" cy="12" r="10" />
+                              <line x1="12" y1="16" x2="12" y2="12" />
+                              <line x1="12" y1="8" x2="12.01" y2="8" />
+                            </svg>
+                          </button>
+                        )}
+                      </div>
                       {stat.linkText && stat.linkUrl && (
                         <a
                           href={stat.linkUrl}
@@ -344,9 +374,33 @@ export default function InsightPanel({
                         <p ref={(el) => (statNumberRefs.current[index + 2] = el)} className={`text-4xl sm:text-5xl md:text-6xl font-light leading-tight ${numberColor}`}>
                           {stat.number}
                         </p>
-                        <p className={`text-sm sm:text-base font-normal ${textColor}`}>
-                          {stat.description}
-                        </p>
+                        <div className="flex items-center gap-2">
+                          <p className={`text-sm sm:text-base font-normal ${textColor}`}>
+                            {stat.description}
+                          </p>
+                          {stat.infoModal && (
+                            <button
+                              onClick={() => setOpenModalIndex(index + 2)}
+                              className={`${textColor} opacity-70 hover:opacity-100 transition-opacity flex-shrink-0`}
+                              aria-label="More information"
+                            >
+                              <svg
+                                width="18"
+                                height="18"
+                                viewBox="0 0 24 24"
+                                fill="none"
+                                stroke="currentColor"
+                                strokeWidth="2"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                              >
+                                <circle cx="12" cy="12" r="10" />
+                                <line x1="12" y1="16" x2="12" y2="12" />
+                                <line x1="12" y1="8" x2="12.01" y2="8" />
+                              </svg>
+                            </button>
+                          )}
+                        </div>
                         {stat.linkText && stat.linkUrl && (
                           <a
                             href={stat.linkUrl}
@@ -366,6 +420,22 @@ export default function InsightPanel({
           </div>
         </div>
       </div>
+
+      {/* Info Modals */}
+      {stats?.map((stat, index) =>
+        stat.infoModal ? (
+          <ContentModal
+            key={index}
+            isOpen={openModalIndex === index}
+            onClose={() => setOpenModalIndex(null)}
+            title={stat.infoModal.title}
+            maxWidth="lg"
+            backgroundColor="bg-goos-blue-900"
+          >
+            {stat.infoModal.content}
+          </ContentModal>
+        ) : null
+      )}
     </section>
   )
 }

--- a/src/components/MenuSidebar.tsx
+++ b/src/components/MenuSidebar.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { gsap } from 'gsap'
 import Button from './Button'
+import { asset } from '../utils/assets'
 
 /**
  * MenuSidebar Component
@@ -371,26 +372,20 @@ export default function MenuSidebar({
 
           <div className="w-full h-px bg-goos-white opacity-20 mb-6"></div>
 
-          {/* Download PDF button with SOON badge */}
+          {/* Download PDF button */}
           <div className="mb-6">
-            <div className="relative inline-block">
-              <Button
-                variant="download"
-                label={t('menu.downloadPdf')}
-                onClick={() => {
-                  // TODO: Uncomment and update the URL when PDF is ready
-                  // const pdfUrl = 'https://example.com/path-to-your-report.pdf'
-                  // window.open(pdfUrl, '_blank')
-                }}
-                textColor="text-white"
-                bgColor="bg-goos-blue-700"
-                iconColor="text-goos-blue-700"
-                iconBgColor="bg-white"
-              />
-              <span className="absolute -top-2 -right-2 bg-goos-orange-500 text-white text-xs font-bold px-2 py-1 rounded-full">
-                {t('menu.comingSoon')}
-              </span>
-            </div>
+            <Button
+              variant="download"
+              label={t('menu.downloadPdf')}
+              onClick={() => {
+                const pdfUrl = asset('/goosreport2025.pdf')
+                window.open(pdfUrl, '_blank')
+              }}
+              textColor="text-white"
+              bgColor="bg-goos-blue-700"
+              iconColor="text-goos-blue-700"
+              iconBgColor="bg-white"
+            />
           </div>
 
           <div className="w-full h-px bg-goos-white opacity-20 mb-6"></div>

--- a/src/components/NetworkCarousel.tsx
+++ b/src/components/NetworkCarousel.tsx
@@ -27,7 +27,7 @@
  *   lineColor="bg-goos-orange-500"
  *   cards={[
  *     {
- *       iconSrc: '/images/argo.png',
+ *       iconSrc: asset('/images/argo.png'),
  *       iconAlt: 'networks.argo.iconAlt',
  *       titleKey: 'networks.argo.title',
  *       networkUrl: 'https://argo.ucsd.edu',

--- a/src/components/PartnerModal.tsx
+++ b/src/components/PartnerModal.tsx
@@ -307,6 +307,13 @@ export default function PartnerModal({
           </button>
         </div>
 
+        {/* Introduction */}
+        <div className="bg-goos-blue-900 px-4 sm:px-6 md:px-8 py-4 sm:py-6">
+          <p className="text-sm sm:text-base text-goos-white leading-relaxed">
+            {t('partners.introduction')}
+          </p>
+        </div>
+
         {/* Content */}
         <div className="space-y-1 bg-goos-blue-900">
           {countries.map((country) => {

--- a/src/components/PartnerModal.tsx
+++ b/src/components/PartnerModal.tsx
@@ -46,23 +46,24 @@
 import { useEffect, useState, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { gsap } from 'gsap'
+import { asset } from '../utils/assets'
 
 // Fixed network types with their icons and translation keys
 const FIXED_NETWORKS = [
-  { key: 'driftingBuoys', icon: '/icons/network/dbcp_drifters.svg', labelKey: 'partners.networks.driftingBuoys' },
-  { key: 'argo', icon: '/icons/network/argo.svg', labelKey: 'partners.networks.argo' },
-  { key: 'oceanGliders', icon: '/icons/network/ocean_gliders.svg', labelKey: 'partners.networks.oceanGliders' },
-  { key: 'aniBOS', icon: '/icons/network/ani_bos.svg', labelKey: 'partners.networks.aniBOS' },
-  { key: 'fvon', icon: '/icons/network/soop.svg', labelKey: 'partners.networks.fvon' },
-  { key: 'sotVos', icon: '/icons/network/vos.svg', labelKey: 'partners.networks.sotVos' },
-  { key: 'sotAsap', icon: '/icons/network/asap.svg', labelKey: 'partners.networks.sotAsap' },
-  { key: 'sot', icon: '/icons/network/xbt-soop.svg', labelKey: 'partners.networks.sot' },
-  { key: 'goShip', icon: '/icons/network/go_ship.svg', labelKey: 'partners.networks.goShip' },
-  { key: 'gloss', icon: '/icons/network/gloss.svg', labelKey: 'partners.networks.gloss' },
-  { key: 'oceanSites', icon: '/icons/network/ocean_sites.svg', labelKey: 'partners.networks.oceanSites' },
-  { key: 'mooredBuoys', icon: '/icons/network/dbcp_moored.svg', labelKey: 'partners.networks.mooredBuoys' },
-  { key: 'tsunamiBuoys', icon: '/icons/network/tsunami_buoys.svg', labelKey: 'partners.networks.tsunamiBuoys' },
-  { key: 'hfRadars', icon: '/icons/network/hf_radar.svg', labelKey: 'partners.networks.hfRadars' },
+  { key: 'driftingBuoys', icon: asset('/icons/network/dbcp_drifters.svg'), labelKey: 'partners.networks.driftingBuoys' },
+  { key: 'argo', icon: asset('/icons/network/argo.svg'), labelKey: 'partners.networks.argo' },
+  { key: 'oceanGliders', icon: asset('/icons/network/ocean_gliders.svg'), labelKey: 'partners.networks.oceanGliders' },
+  { key: 'aniBOS', icon: asset('/icons/network/ani_bos.svg'), labelKey: 'partners.networks.aniBOS' },
+  { key: 'fvon', icon: asset('/icons/network/soop.svg'), labelKey: 'partners.networks.fvon' },
+  { key: 'sotVos', icon: asset('/icons/network/vos.svg'), labelKey: 'partners.networks.sotVos' },
+  { key: 'sotAsap', icon: asset('/icons/network/asap.svg'), labelKey: 'partners.networks.sotAsap' },
+  { key: 'sot', icon: asset('/icons/network/xbt-soop.svg'), labelKey: 'partners.networks.sot' },
+  { key: 'goShip', icon: asset('/icons/network/go_ship.svg'), labelKey: 'partners.networks.goShip' },
+  { key: 'gloss', icon: asset('/icons/network/gloss.svg'), labelKey: 'partners.networks.gloss' },
+  { key: 'oceanSites', icon: asset('/icons/network/ocean_sites.svg'), labelKey: 'partners.networks.oceanSites' },
+  { key: 'mooredBuoys', icon: asset('/icons/network/dbcp_moored.svg'), labelKey: 'partners.networks.mooredBuoys' },
+  { key: 'tsunamiBuoys', icon: asset('/icons/network/tsunami_buoys.svg'), labelKey: 'partners.networks.tsunamiBuoys' },
+  { key: 'hfRadars', icon: asset('/icons/network/hf_radar.svg'), labelKey: 'partners.networks.hfRadars' },
 ] as const
 
 type NetworkKey = typeof FIXED_NETWORKS[number]['key']

--- a/src/components/SatelliteTable.tsx
+++ b/src/components/SatelliteTable.tsx
@@ -396,22 +396,6 @@ export default function SatelliteTable() {
                   </p>
                 </div>
 
-                {/* Contacts Section */}
-                <div>
-                  <h3 className="text-base sm:text-lg text-goos-orange-500 mb-2 sm:mb-3">
-                    {t('satelliteObservations.platformModal.contactsTitle')}
-                  </h3>
-                  <div className="space-y-1 text-sm sm:text-base text-white">
-                    <p>{t('satelliteObservations.platformModal.contacts.sst')}</p>
-                    <p>{t('satelliteObservations.platformModal.contacts.sss')}</p>
-                    <p>{t('satelliteObservations.platformModal.contacts.seaLevel')}</p>
-                    <p>{t('satelliteObservations.platformModal.contacts.winds')}</p>
-                    <p>{t('satelliteObservations.platformModal.contacts.seaIce')}</p>
-                    <p>{t('satelliteObservations.platformModal.contacts.seaState')}</p>
-                    <p>{t('satelliteObservations.platformModal.contacts.oceanColor')}</p>
-                  </div>
-                </div>
-
                 {/* SST */}
                 <div>
                   <h3 className="text-base sm:text-lg text-goos-orange-500 mb-2 sm:mb-3">

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -249,7 +249,9 @@
       "stats": {
         "stat1": {
           "number": "64",
-          "description": "contributing countries"
+          "description": "contributing countries",
+          "infoModalTitle": "About Contributing Countries Count",
+          "infoModalContent": "In this edition, the number of contributing Member States appears lower than in the 2023 GOOS Report Card. This is primarily due to the application of updated operational criteria for GLOSS stations, as agreed with the GLOSS Steering Team, and a revision of how EU contributions to GOOS are counted—treating the European Union as a single entity rather than as 27 individual countries, as previously done. This refined methodology will be maintained in future editions of the GOOS Status Report."
         },
         "stat2": {
           "number": "17",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -661,16 +661,6 @@
       "title": "Essential Climate and Ocean Variables observed from space",
       "introduction": "This document provides additional information on the adequacy, continuity, and requirements of satellite observations for each Essential Ocean and Climate Variable, as contributed by the satellite ocean observing community. It summarizes the current status and future outlook of satellite measurements for each variable, outlining key achievements, challenges, and planned missions.",
       "moreButton": "More…",
-      "contactsTitle": "Contacts",
-      "contacts": {
-        "sst": "SST: Jorge Vazquez (jorge.vazquez@jpl.nasa.gov), Christina Gonzalez-Haro (cgharo@icm.csic.es)",
-        "sss": "SSS: Severine Fournier (severine.fournier@jpl.nasa.gov)",
-        "seaLevel": "Sea Level: Severine Fournier (severine.fournier@jpl.nasa.gov)",
-        "seaState": "Sea State: Lotfi Aouf (lotfi.aouf@meteo.fr)",
-        "winds": "Winds: Mark Bourassa (bourassa@coaps.fsu.edu); Tong Lee (tlee@jpl.nasa.gov)",
-        "seaIce": "Sea Ice: Ted Maksym (tmaksym@whoi.edu); Stephen Howell (stephen.howell@ec.gc.ca); Walter Meier (walt@colorado.edu)",
-        "oceanColor": "Ocean Color: Christine Lee (christine.lee@jpl.nasa.gov)"
-      },
       "variables": {
         "sst": {
           "title": "SEA SURFACE TEMPERATURE:",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -823,6 +823,7 @@
   },
   "partners": {
     "title": "Our Partners",
+    "introduction": "In this edition, the number of contributing Member States appears lower than in the 2023 GOOS Report Card. This is primarily due to the application of updated operational criteria for GLOSS stations, as agreed with the GLOSS Steering Team, and a revision of how EU contributions to GOOS are counted—treating the European Union as a single entity rather than as 27 individual countries, as previously done. This refined methodology will be maintained in future editions of the GOOS Status Report.",
     "networksLabel": "Networks",
     "platformsLabel": "Platforms",
     "viewFullListButton": "VIEW FULL LIST",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -243,7 +243,9 @@
       "stats": {
         "stat1": {
           "number": "64",
-          "description": "países contribuyentes"
+          "description": "países contribuyentes",
+          "infoModalTitle": "Acerca del conteo de países contribuyentes",
+          "infoModalContent": "En esta edición, el número de Estados Miembros contribuyentes aparece inferior al de la Tarjeta de Reporte GOOS 2023. Esto se debe principalmente a la aplicación de criterios operacionales actualizados para las estaciones GLOSS, según lo acordado con el Equipo Directivo de GLOSS, y a una revisión de cómo se contabilizan las contribuciones de la UE a GOOS—tratando a la Unión Europea como una sola entidad en lugar de como 27 países individuales, como se hacía anteriormente. Esta metodología refinada se mantendrá en futuras ediciones del Informe de Estado de GOOS."
         },
         "stat2": {
           "number": "13",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -243,7 +243,9 @@
       "stats": {
         "stat1": {
           "number": "64",
-          "description": "pays contributeurs"
+          "description": "pays contributeurs",
+          "infoModalTitle": "À propos du décompte des pays contributeurs",
+          "infoModalContent": "Dans cette édition, le nombre d'États membres contributeurs semble inférieur à celui de la Carte de Rapport GOOS 2023. Cela est principalement dû à l'application de critères opérationnels mis à jour pour les stations GLOSS, comme convenu avec l'équipe directrice de GLOSS, et à une révision de la façon dont les contributions de l'UE au GOOS sont comptabilisées—traitant l'Union européenne comme une seule entité plutôt que comme 27 pays individuels, comme cela se faisait auparavant. Cette méthodologie affinée sera maintenue dans les futures éditions du Rapport de Statut GOOS."
         },
         "stat2": {
           "number": "13",

--- a/src/utils/assets.ts
+++ b/src/utils/assets.ts
@@ -1,0 +1,19 @@
+/**
+ * Asset path helper for base URL resolution
+ *
+ * Prepends the Vite base URL to asset paths for deployment to subdirectories.
+ * When base is '/', paths remain unchanged.
+ * When base is '/demos/report-card/', paths get that prefix.
+ *
+ * @param p - Asset path starting with '/'
+ * @returns Full path with base URL prepended
+ *
+ * @example
+ * // In staging (base = '/')
+ * asset('/images/photo.jpg') // → '/images/photo.jpg'
+ *
+ * // In production (base = '/demos/report-card/')
+ * asset('/images/photo.jpg') // → '/demos/report-card/images/photo.jpg'
+ */
+export const asset = (p: string) =>
+  `${import.meta.env.BASE_URL}${p.replace(/^\/+/, '')}`


### PR DESCRIPTION
## Summary
This release includes important updates for the 2025 GOOS Report Card, implementation of a unified asset path approach for both staging and production deployments, and several content refinements based on stakeholder feedback.

## Key Changes

### 🎯 2025 Updates
- **README**: Updated year references to 2025
- **PDF Download**: Added GOOS Report 2025 PDF (23MB) and enabled download functionality in menu
- **Documentation**: Updated project documentation to reflect 2025 edition

### 🔧 Unified Asset Path Approach
- **New `asset()` helper**: Created utility function for dynamic base URL resolution
- **Staging deployment**: Assets load from root (`/`)
- **Production deployment**: Assets load from subdirectory (`/demos/report-card/`)
- **All asset paths updated**: Images, icons, videos, and PDF now use `asset()` helper
- **Benefits**: Single codebase works in both environments without manual path editing

### 📝 Content Updates

#### Partners Modal
- Added introduction text explaining why member states count appears lower than 2023
- Explains updated GLOSS operational criteria and EU counting methodology
- Available in English, Spanish, and French

#### Contributing Countries Stat
- Added info icon (ⓘ) with modal next to "64 contributing countries"
- Modal contains detailed explanation of counting methodology changes
- Consistent styling with other modals (blue background, white text)
- Translations in all three languages

#### Satellite Platform Modal
- Removed contacts section (emails for SST, SSS, Sea Level, etc.)
- Cleaner, more focused content

#### Component Improvements
- **DataCard**: Removed fixed icon sizing to allow parent container control
- Better flexibility for different use cases

## Files Changed
- `README.md`
- `src/utils/assets.ts` (new)
- `src/App.tsx`
- `src/components/InsightPanel.tsx`
- `src/components/MenuSidebar.tsx`
- `src/components/PartnerModal.tsx`
- `src/components/SatelliteTable.tsx`
- `src/components/DataCard.tsx`
- `src/locales/en.json`
- `src/locales/es.json`
- `src/locales/fr.json`
- `public/goosreport2025.pdf` (new, 23MB)

## Technical Notes
- `vite.config.ts` in main branch must remain unchanged (has `base: '/demos/report-card/'`)
- All components now use `asset()` for path resolution
- `.gitattributes` protects `vite.config.ts` in main during merges

## Testing Checklist
- [x] Assets load correctly in staging environment
- [x] PDF download works
- [x] Info modal opens and displays correctly
- [x] Partners modal shows introduction text
- [x] Satellite modal no longer shows contacts
- [x] All translations work (EN, ES, FR)
- [x] No console errors
- [x] Responsive on all screen sizes

## Deployment
Once merged to main, this will deploy automatically to production at `/demos/report-card/` with all asset paths working correctly.