### PR TITLE
Fix typo in OceanGliders title

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -510,7 +510,7 @@
       "iconAlt": "Argo Network - Global array of profiling floats measuring ocean temperature and salinity"
     },
     "gliders": {
-      "title": "Gliders – OceanGliderss",
+      "title": "Gliders – OceanGliders",
       "iconAlt": "OceanGliders Network - Global network of autonomous underwater gliders"
     },
     "anibos": {


### PR DESCRIPTION
## Summary
- Fix typo in OceanGliders network title

## Changes
- Changed "Gliders – OceanGliderss" to "Gliders – OceanGliders" (removed extra 's')

## Files Modified
- `src/locales/en.json`

## Test Plan
- [x] Typo corrected in English translation