### PR TITLE
Update PDF and fix typo

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -510,7 +510,7 @@
       "iconAlt": "Argo Network - Global array of profiling floats measuring ocean temperature and salinity"
     },
     "gliders": {
-      "title": "Gliders – OceanGliderss",
+      "title": "Gliders – OceanGliders",
       "iconAlt": "OceanGliders Network - Global network of autonomous underwater gliders"
     },
     "anibos": {


### PR DESCRIPTION
## Summary
- Update GOOS Report 2025 PDF
- Fix typo in OceanGliders network title

## Changes

### PDF Update
- Updated GOOS Report 2025 PDF (24.6MB → 24.6MB)
- Latest version of the report

### Translation Fix
- Fixed typo in English translation: "OceanGliderss" → "OceanGliders"
- File: `src/locales/en.json`

## Test Plan
- [x] PDF downloads correctly
- [x] Typo corrected in network title
- [x] No breaking changes