### PR TITLE
Fix Plyr video controls positioning

### DIFF
--- a/src/components/VideoModal.tsx
+++ b/src/components/VideoModal.tsx
@@ -268,8 +268,7 @@ export default function VideoModal({
                   title="YouTube video player"
                 />
               ) : (
-                <div className="plyr-video-wrapper" style={{
-                  width: '100%',
+                <div className="plyr-video-wrapper aspect-video w-full" style={{
                   maxHeight: '90vh',
                   display: 'flex',
                   alignItems: 'center',
@@ -278,19 +277,19 @@ export default function VideoModal({
                   <style>{`
                     .plyr-video-wrapper .plyr {
                       width: 100% !important;
-                      height: auto !important;
+                      height: 100% !important;
                       max-height: 90vh !important;
                       --plyr-color-main: #F48B25;
                     }
                     .plyr-video-wrapper .plyr video {
                       width: 100% !important;
-                      height: auto !important;
+                      height: 100% !important;
                       max-height: 90vh !important;
                       object-fit: contain !important;
                     }
                     .plyr-video-wrapper .plyr__video-wrapper {
                       padding-bottom: 0 !important;
-                      height: auto !important;
+                      height: 100% !important;
                     }
                   `}</style>
                   <Plyr


### PR DESCRIPTION
## Summary
- Fix Plyr controls appearing in wrong position during video load

## Changes

### Bug Fix
- **VideoModal**: Added `aspect-video` class to Plyr wrapper to maintain 16:9 ratio from initial render
- Changed Plyr container heights from `auto` to `100%` to fill the aspect ratio container properly

## Technical Details
- Plyr wrapper now uses `aspect-video w-full` classes
- All height values changed to `100%` to properly fill the fixed-ratio container
- Controls appear in correct position immediately, no vertical shift during load

## Before
- Plyr wrapper had no fixed dimensions
- Controls appeared at top until video loaded
- Visual jump when video dimensions were established

## After  
- Plyr wrapper maintains 16:9 aspect ratio from start
- Controls positioned correctly from initial render
- No visual jump or repositioning

## Test Plan
- [x] Open local video modal
- [x] Controls appear in correct position immediately
- [x] No height jump during load
- [x] Video plays correctly
- [x] Build succeeds