### PR TITLE
Add storybook-static to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+storybook-static
 *.local
 
 # Claude Code


### PR DESCRIPTION
Add storybook-static build folder to .gitignore to prevent committing build artifacts.