### PR TITLE
Deploy staging changes to production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+storybook-static
 *.local
 
 # Claude Code

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1357,7 +1357,7 @@ function App() {
                     <Button
                       variant="link"
                       label={t('networks.viewNetwork')}
-                      url="https://www.aoml.noaa.gov/ocd/gcc/SOCONET/"
+                      url="https://www.ioccp.org/soconet"
                       bgColor="bg-goos-orange-600"
                       textColor="text-white"
                       iconBgColor="bg-white"
@@ -1372,7 +1372,7 @@ function App() {
             titleKey: 'emerging.soconet.title',
             paragraph1Key: 'emerging.soconet.paragraph1WithLink',
             paragraph2Key: 'emerging.soconet.paragraph2',
-            externalLinkUrl: 'https://www.aoml.noaa.gov/ocd/gcc/SOCONET/',
+            externalLinkUrl: 'https://www.ioccp.org/soconet',
             externalLinkTextKey: 'networks.viewNetwork',
             deliveryAreasLabelKey: 'networks.deliveryAreasLabel',
             deliveryAreas: ['climate', 'oceanhealth'],


### PR DESCRIPTION
## Summary
- Update SOCONET external link URL
- Add storybook-static to gitignore

## Changes

### SOCONET URL Update
- Changed SOCONET external link from `aoml.noaa.gov` to `ioccp.org/soconet`
- Updated both button URL and modal external link

### Gitignore
- Added `storybook-static` to gitignore to exclude Storybook build artifacts

## Files Changed
- `src/App.tsx`: Updated SOCONET URLs (2 locations)
- `.gitignore`: Added storybook-static directory

## Test Plan
- Verified SOCONET links point to correct URL
- Confirmed storybook-static directory is ignored by git